### PR TITLE
Fix #2 - Corner case: 'Singleton variables' cause corruption in change handling

### DIFF
--- a/properties-from-ancestor-behavior.html
+++ b/properties-from-ancestor-behavior.html
@@ -62,17 +62,16 @@ while their values will come from the closest ancestor that has the correspondin
         return Object.keys(propsDefObject).map(function (propName) {
                 var propDef = propsDefObject[propName];
 
-                var ancestorWithAttribute = undefined;
-
                 var dashedName = fromCamelCaseSymbolToDash(propName);
                 var changeEventName = dashedName + '-changed';
-                var changeEventListener;
 
                 var behaviorDefinition = {
                     properties: {},
                     attached: function () {
-
-                        ancestorWithAttribute = polymerClosestWithAttribute(this, dashedName);
+                        var ancestorWithAttribute = polymerClosestWithAttribute(this, dashedName);
+                        this.__propertiesFromAncestorBehavior = {
+                            ancestorWithAttribute: ancestorWithAttribute,
+                        };
 
                         this[propName] =
                             !ancestorWithAttribute ?
@@ -84,15 +83,18 @@ while their values will come from the closest ancestor that has the correspondin
                                     ancestorWithAttribute.getAttribute(dashedName);
 
                         if (ancestorWithAttribute) {
-                            changeEventListener = function changeEventListener() {
-                                this[propName] = ancestorWithAttribute[propName];
-                            }.bind(this);
-                            ancestorWithAttribute.addEventListener(changeEventName, changeEventListener);
+                            ;
+                            ancestorWithAttribute.addEventListener(
+                                    changeEventName,
+                                    this.__propertiesFromAncestorBehavior.changeEventListener = function () {
+                                        this[propName] = ancestorWithAttribute[propName];
+                                    }.bind(this)
+                                );
                         }
                     },
                     detached: function () {
-                        if (ancestorWithAttribute)
-                            ancestorWithAttribute.removeEventListener(changeEventName, changeEventListener);
+                        if (this.__propertiesFromAncestorBehavior.ancestorWithAttribute)
+                            this.__propertiesFromAncestorBehavior.ancestorWithAttribute.removeEventListener(changeEventName, this.__propertiesFromAncestorBehavior.changeEventListener);
                     },
                 };
 

--- a/test/properties-from-ancestor-behavior_test.html
+++ b/test/properties-from-ancestor-behavior_test.html
@@ -199,5 +199,44 @@
             });
         });
     </script>
+
+    <test-fixture id="two-instances-of-same-descendant-in-containers-with-different-properties">
+        <template>
+            <div>
+                <test-ancestor-component-as-container id="ancestor1" my-prop1="initialValue">
+                    <test-descendant-component></test-descendant-component>
+                </test-ancestor-component-as-container>
+                <test-ancestor-component-as-container id="ancestor2" my-prop1="initialValue">
+                    <test-descendant-component></test-descendant-component>
+                </test-ancestor-component-as-container>
+                <div my-prop1="valueForDescendant1">
+                </div>
+                <div my-prop1="valueForDescendant2">
+                </div>
+            </div>
+        </template>
+    </test-fixture>
+    <script>
+        suite('two-instances-of-same-descendant-in-containers-with-different-properties', function () {
+            var ancestor1;
+            var ancestor2;
+            var descendant1;
+            var descendant2;
+            setup(function () {
+                var template = fixture('two-instances-of-same-descendant-in-containers-with-different-properties');
+                ancestor1 = template.querySelector('#ancestor1');
+                ancestor2 = template.querySelector('#ancestor2');
+                descendant1 = ancestor1.querySelector('test-descendant-component');
+                descendant2 = ancestor2.querySelector('test-descendant-component');
+            });
+
+            test('each descendant receives value of its ancestor', function () {
+                ancestor1.myProp1 = 'valueForDescendant1';
+                expect(descendant1.myProp1).to.be.equal("valueForDescendant1");
+                ancestor2.myProp1 = 'valueForDescendant2';
+                expect(descendant2.myProp1).to.be.equal("valueForDescendant2");
+            });
+        });
+    </script>
 </body>
 </html>

--- a/test/properties-from-ancestor-behavior_test.html
+++ b/test/properties-from-ancestor-behavior_test.html
@@ -78,7 +78,7 @@
             setup(function () {
                 ancestor = fixture('plain-html-custom-prop-declaration');
                 descendant = ancestor.querySelector('test-descendant-component-with-custom-prop-declaration');
-                descendant.myProp1 = 'newValue'
+                descendant.myProp1 = 'newValue';
             });
 
             test('when property declaration has `reflectToAttribute`, it works', function () {


### PR DESCRIPTION
Fixes #2

(problem only affects use cases with many components of the same type in many ancestors) - instances start taking value from the last initialized ancestor

This is my bad. The `ancestorWithAttribute`  and `changeEventListener` variables may not have been global, but I actually made them a singleton-per-inheriting-class, while they should be per-instance.
The fix it to move these variables to properties on the element.

First commit ads a failing test that demonstrates the problem. A fix is in the next commit.