### PR TITLE
Address Issue #13 - Corner case memory leak - when behavior used many times on same element and element gets detached

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Polymer({
         PropertiesFromAncestorBehavior({
             // Just declaring a property here is enough to make it work.
             myProp1: {
-                // Optionally, you can provide a default. If no ancestor is found, `defaultValue` will to be used:
+                // Optionally, you can provide a default. If no ancestor is found, `defaultValue` will be used:
                 defaultValue: 123, // (don't use the polymer's 'value:' for this though, because it may cause double initialization - once with such value, once with the value from ancestor (if they're different). That's because we can only reach the ancestor on 'attached', which happens after defaults get applied.
 
                 // See "API Reference - Per-Property settings" for all available options
@@ -90,7 +90,7 @@ while their values will come from the closest ancestor that has the correspondin
 # API Reference - Per-Property settings #
 These parameters can be specified for each property:
 - **defaultValue** (_Optional_)  
-  If no ancestor is found, `defaultValue` will to be used.  
+  If no ancestor is found, `defaultValue` will be used.  
 - **ancestorMatches** (_Optional_)
   of type <a href="ttps://www.w3.org/TR/selectors4/" target="_blank">HTML Selector</a>  
   - Instead of looking for ancestor with the dash-case attribute, you can provide a selector. This especially is needed for boolean attributes that start with 'false', because it's represented as no attribute at all.

--- a/properties-from-ancestor-behavior.html
+++ b/properties-from-ancestor-behavior.html
@@ -17,7 +17,7 @@ Polymer({
         PropertiesFromAncestorBehavior({
             // Just declaring a property here is enough to make it work.
             myProp1: {
-                // Optionally, you can provide a default. If no ancestor is found, `defaultValue` will to be used:
+                // Optionally, you can provide a default. If no ancestor is found, `defaultValue` will be used:
                 defaultValue: 123, // (don't use the polymer's 'value:' for this though, because it may cause double initialization - once with such value, once with the value from ancestor (if they're different). That's because we can only reach the ancestor on 'attached', which happens after defaults get applied.
 
                 // See "API Reference - Per-Property settings" for all available options
@@ -59,7 +59,7 @@ while their values will come from the closest ancestor that has the correspondin
 # API Reference - Per-Property settings #
 These parameters can be specified for each property:
 - **defaultValue** (_Optional_)  
-  If no ancestor is found, `defaultValue` will to be used.  
+  If no ancestor is found, `defaultValue` will be used.  
 - **ancestorMatches** (_Optional_)
   of type <a href="ttps://www.w3.org/TR/selectors4/" target="_blank">HTML Selector</a>  
   - Instead of looking for ancestor with the dash-case attribute, you can provide a selector. This especially is needed for boolean attributes that start with 'false', because it's represented as no attribute at all.

--- a/properties-from-ancestor-behavior.html
+++ b/properties-from-ancestor-behavior.html
@@ -161,8 +161,10 @@ Polymer({
                     properties: {},
                     attached: function () {
                         let ancestorToObserve = polymerClosestThatMatches(this, propDef.ancestorMatches || '[' + dashedName + ']');
-                        this.__propertiesFromAncestorBehavior = {
-                        };
+                        if (!this.__propertiesFromAncestorBehavior)
+                            this.__propertiesFromAncestorBehavior = {
+                                observers: [],
+                            };
 
                         this[propName] =
                             !ancestorToObserve ?
@@ -198,12 +200,13 @@ Polymer({
                                 };
                             }
 
-                            this.__propertiesFromAncestorBehavior.observer = observer;
+                            this.__propertiesFromAncestorBehavior.observers.push(observer);
                         }
                     },
                     detached: function () {
-                        if (this.__propertiesFromAncestorBehavior.observer)
-                            this.__propertiesFromAncestorBehavior.observer.disconnect();
+                        let observer;
+                        while (observer = this.__propertiesFromAncestorBehavior.observers.pop())
+                            observer.disconnect();
                     },
                 };
 

--- a/test/properties-from-ancestor-behavior_test.html
+++ b/test/properties-from-ancestor-behavior_test.html
@@ -17,6 +17,7 @@
     <link rel="import" href="../test_components/test-descendant-component-with-custom-prop-declaration.html">
     <link rel="import" href="../test_components/test-descendant-component-disablable-from-fieldset-starting-as-false.html">
     <link rel="import" href="../test_components/test-descendant-component-with-language-prop-from-lang-in-ancestor.html">
+    <link rel="import" href="../test_components/test-descendant-component-with-multiple-usages-of-the-mixin.html">
   </head>
 <body>
     <test-fixture id="plain-html-direct-value">
@@ -344,6 +345,57 @@
                 expect(descendant1.myProp1).to.be.equal("valueForDescendant1");
                 ancestor2.myProp1 = 'valueForDescendant2';
                 expect(descendant2.myProp1).to.be.equal("valueForDescendant2");
+            });
+        });
+    </script>
+
+    <test-fixture id="memory-cleanup-on-detach-with-multiple-usages-of-the-mixin">
+        <template>
+            <div my-prop1="whatev" my-prop2="whatev">
+                <!-- Use the component that uses our mixin many times, so that we can detect potential errors of same initializer erasing the observers of the previous run, when executed multiple times. -->
+                <test-descendant-component-with-multiple-usages-of-the-mixin></test-descendant-component-with-multiple-usages-of-the-mixin>
+            </div>
+        </template>
+    </test-fixture>
+    <script>
+        suite('memory-cleanup-on-detach-with-multiple-usages-of-the-mixin', function () {
+            let ancestor;
+            let descendant;
+            setup(function () {
+                ancestor = fixture('memory-cleanup-on-detach-with-multiple-usages-of-the-mixin');
+                descendant = ancestor.querySelector('test-descendant-component-with-multiple-usages-of-the-mixin');
+            });
+
+            test('each usages observer gets disconnected', function (done) {
+                let disconnectFired = false;
+
+                var observers = descendant.__propertiesFromAncestorBehavior.observers;
+
+                let observersLength = observers.length;
+                let observersDisconnectCalls = 0;
+
+                expect(observersLength).to.not.be.equal(0);
+
+                for (let i = 0; i < observersLength; i++) {
+                    let observer = observers[i];
+                    let originalDisconnect = observer.disconnect;
+                    observer.disconnect = function () {
+                        originalDisconnect.apply(this, arguments);
+                        ++observersDisconnectCalls;
+                    };
+                }
+                ancestor.parentNode.removeChild(ancestor);
+
+                setTimeout(() => { // Needed at least for Polymer 1.X on Firefox and IE. Didn't seem to be needed for Polymer 2.0
+                    try {
+                        expect(observersDisconnectCalls).to.be.equal(observersLength);
+                        expect(observers).to.be.empty;
+                        done();
+                    }
+                    catch (e) {
+                        done(e);
+                    }
+                }, 0);
             });
         });
     </script>

--- a/test_components/test-descendant-component-with-default.html
+++ b/test_components/test-descendant-component-with-default.html
@@ -1,6 +1,6 @@
 ﻿<link rel="import" href="../../polymer/polymer.html" />
 <link rel="import" href="../properties-from-ancestor-behavior.html"/>
-<dom-module id="test-descendant-component">
+<dom-module id="test-descendant-component-with-default">
     <template>
         <h1>Descendant component</h1>
         myProp1 value is {{myProp1}}

--- a/test_components/test-descendant-component-with-multiple-usages-of-the-mixin.html
+++ b/test_components/test-descendant-component-with-multiple-usages-of-the-mixin.html
@@ -1,0 +1,28 @@
+﻿<link rel="import" href="../../polymer/polymer.html" />
+<link rel="import" href="../properties-from-ancestor-behavior.html"/>
+<dom-module id="test-descendant-component-with-multiple-usages-of-the-mixin">
+    <template>
+        <h1>Descendant component</h1>
+        myProp1 value is {{myProp1}}
+        myProp2 value is {{myProp2}}
+    </template>
+</dom-module>
+<script>
+    Polymer({
+        is: "test-descendant-component-with-multiple-usages-of-the-mixin",
+        behaviors: [
+            PropertiesFromAncestorBehavior({
+                myProp1: {
+                },
+            }),
+            PropertiesFromAncestorBehavior({
+                myProp2: {
+                },
+            }),
+        ],
+        properties: {
+            myProp1: {},
+            myProp2: {},
+        },
+    });
+</script>


### PR DESCRIPTION
This fixes the problem outlined in issue #13.

It achieves this by preventing override of `Element.__propertiesFromAncestorBehavior.observer` by rather turning it into an array (now called `observers`) to which each behavior merely adds, instead of overwriting. 

Test included.